### PR TITLE
feat: Add resizable song card with customizable sizing options

### DIFF
--- a/pkgs/routes/routes.go
+++ b/pkgs/routes/routes.go
@@ -40,9 +40,14 @@ type RequestJSON struct {
 
 // SongData represents the data for the song
 type SongData struct {
-	Title    string
-	Artist   string
-	AlbumArt string
+	Title         string
+	Artist        string
+	AlbumArt      string
+	Width         string
+	Height        string
+	AlbumArtSize  string
+	TitleFontSize string
+	ArtistFontSize string
 }
 
 // Router is the struct that handles all routes
@@ -653,7 +658,8 @@ func (rt *Router) StreamOfflineHandler(_ http.ResponseWriter, r *http.Request) {
 }
 
 // PlayingHandler displays music playing in spotify
-func (rt *Router) PlayingHandler(w http.ResponseWriter, _ *http.Request) {
+// Supports query parameters: ?size=full|half|small or ?width=Xpx&height=Ypx
+func (rt *Router) PlayingHandler(w http.ResponseWriter, r *http.Request) {
 	song, err := rt.Spotify.GetSong()
 	if err != nil {
 		rt.Log.Error("Failed to get current song", err)
@@ -670,10 +676,32 @@ func (rt *Router) PlayingHandler(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+
+	// Parse query parameters for sizing
+	query := r.URL.Query()
+	width, height, albumArtSize, titleFontSize, artistFontSize := rt.getSizeDefaults()
+
+	if sizePreset := query.Get("size"); sizePreset != "" {
+		width, height, albumArtSize, titleFontSize, artistFontSize = rt.getSizePreset(sizePreset)
+	} else {
+		// Allow custom width/height
+		if customWidth := query.Get("width"); customWidth != "" {
+			width = customWidth
+		}
+		if customHeight := query.Get("height"); customHeight != "" {
+			height = customHeight
+		}
+	}
+
 	data := SongData{
-		Title:    song.Item.Name,
-		Artist:   song.Item.Artists[0].Name,
-		AlbumArt: song.Item.Album.Images[0].URL,
+		Title:          song.Item.Name,
+		Artist:         song.Item.Artists[0].Name,
+		AlbumArt:       song.Item.Album.Images[0].URL,
+		Width:          width,
+		Height:         height,
+		AlbumArtSize:   albumArtSize,
+		TitleFontSize:  titleFontSize,
+		ArtistFontSize: artistFontSize,
 	}
 	tmpl, err := template.ParseFiles("./templates/index.html")
 	if err != nil {
@@ -685,6 +713,27 @@ func (rt *Router) PlayingHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		http.Error(w, "Error executing template", http.StatusInternalServerError)
 		return
+	}
+}
+
+// getSizeDefaults returns default size values
+func (rt *Router) getSizeDefaults() (string, string, string, string, string) {
+	return "250px", "100px", "80px", "1em", "1em"
+}
+
+// getSizePreset returns sizing based on preset names
+func (rt *Router) getSizePreset(preset string) (string, string, string, string, string) {
+	switch preset {
+	case "full":
+		return "100vw", "100vh", "40vh", "3em", "2em"
+	case "half":
+		return "50vw", "50vh", "20vh", "2.5em", "1.8em"
+	case "large":
+		return "600px", "400px", "300px", "2em", "1.5em"
+	case "small":
+		return "200px", "80px", "60px", "0.9em", "0.8em"
+	default:
+		return rt.getSizeDefaults()
 	}
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="refresh" content="10" />
     <style>
+      :root {
+        --card-width: {{ .Width }};
+        --card-height: {{ .Height }};
+        --album-art-size: {{ .AlbumArtSize }};
+        --title-font-size: {{ .TitleFontSize }};
+        --artist-font-size: {{ .ArtistFontSize }};
+      }
+
       body {
         background-color: transparent; /* Transparent background for the page */
         color: #e0e0e0; /* Light text color (will be mostly for potential fallback or if other elements are added) */
@@ -24,8 +32,8 @@
       }
 
       .song-container {
-        width: 250px;
-        height: 100px;
+        width: var(--card-width);
+        height: var(--card-height);
         border: 1px solid #333;
         display: flex;
         align-items: center;
@@ -39,26 +47,40 @@
       }
 
       .album-art {
-        width: 80px;
-        height: 80px;
+        width: var(--album-art-size);
+        height: var(--album-art-size);
         margin-right: 10px;
         object-fit: cover;
         border-radius: 6px;
+        flex-shrink: 0;
       }
 
       .song-details {
         flex-grow: 1;
+        overflow: hidden;
       }
 
       .song-title {
-        font-size: 1em;
+        font-size: var(--title-font-size);
         font-weight: bold;
         margin-bottom: 2px;
+        word-wrap: break-word;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
       }
 
       .song-artist {
-        font-size: 1em;
+        font-size: var(--artist-font-size);
         color: #bbb;
+        word-wrap: break-word;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
       }
     </style>
   </head>


### PR DESCRIPTION
- Add support for size presets: ?size=full|half|large|small
- Add support for custom dimensions: ?width=Xpx&height=Ypx
- Convert hardcoded card dimensions to CSS variables
- Scale all text and album art proportionally based on preset
- Improve text wrapping and overflow handling for larger displays
- Default card remains 250x100px for backward compatibility

This allows users to control the overlay size when importing the playing
endpoint as a browser source in streaming applications.